### PR TITLE
fix: 修复EInputSize组件在某些情况下单位显示不正常以及无法输入部分数字的问题

### DIFF
--- a/packages/core/extensions/EInputSize/index.vue
+++ b/packages/core/extensions/EInputSize/index.vue
@@ -31,12 +31,14 @@ const unitArray = [
 watch(() => props.modelValue, e => {
   const num = parseFloat(e)
   // 传入值为空或不正常时
-  if (!num) {
+  if (isNaN(num)) {
     size.value = null
     return false
   }
-  size.value = String(num)
-  unit.value = e.substring(size.value.length)
+  const regex = /^(\d+(\.\d+)?)(px|%|vw|vh|rem|em|pt){1}$/
+  const match = e.trim().match(regex)
+  size.value = match?.[1] ?? null
+  unit.value = match?.[3] ?? ''
 }, {
   immediate: true
 })


### PR DESCRIPTION
**问题描述**: 
- 输入部分数字,如0.1时,单位会由px变成x
- 输入1.01时, 0会被清除, 变成11