### PR TITLE
fix: 修复pageSchema中包含'#'字符时,导出数据被截断的问题

### DIFF
--- a/packages/core/components/designer/src/modules/editContainer/previewJson.vue
+++ b/packages/core/components/designer/src/modules/editContainer/previewJson.vue
@@ -46,9 +46,8 @@ function handleOpen() {
  * 导出数据
  */
 function handleExportData(fileName = `epic-data.json`) {
-  let content = "data:text/json;charset=utf-8,";
-  content += JSON.stringify(pageSchema, null, 2);
-  var encodedUri = encodeURI(content);
+  const content = JSON.stringify(pageSchema, null, 2);
+  var encodedUri = `data:text/json;charset=utf-8,${encodeURIComponent(content)}`;
   var actions = document.createElement("a");
   actions.setAttribute("href", encodedUri);
   actions.setAttribute("download", fileName);


### PR DESCRIPTION
**复现示例:**
```json
{
  "schemas": [
    {
      "type": "page",
      "id": "root",
      "label": "页面",
      "children": [],
      "componentProps": {
        "style": {
          "padding": "16px",
          "backgroundColor": "#3d22c3"
        }
      }
    }
  ],
  "script": "const { defineExpose, find } = epic;\n\nfunction test (){\n    console.log('test')\n}\n\n// 通过defineExpose暴露的函数或者属性\ndefineExpose({\n test \n})"
}
```
**导出结果:**
```json
{
  "schemas": [
    {
      "type": "page",
      "id": "root",
      "label": "页面",
      "children": [],
      "componentProps": {
        "style": {
          "padding": "16px",
          "backgroundColor": "
```