### PR TITLE
fix:修复事件配置中，由于组件相同导致没有重新渲染的问题

### DIFF
--- a/packages/core/extensions/EActionEditor/src/EActionModal.vue
+++ b/packages/core/extensions/EActionEditor/src/EActionModal.vue
@@ -69,6 +69,7 @@
         </div>
         <EArgsEditor
           v-else
+          :key="argsEditorKey"
           v-model="state.actionItem.args"
           :actionArgsConfigs="actionArgsConfigs"
         />
@@ -85,7 +86,7 @@ import {
   findSchemaById,
   getUUID,
 } from "@epic-designer/utils";
-import { ref, inject, toRaw, reactive, computed, nextTick } from "vue";
+import { ref, inject, toRaw, reactive, computed, nextTick, watch } from "vue";
 import ETree from "../../../components/tree";
 import { ComponentSchema, PageSchema, FormDataModel } from "../../../types/epic-designer";
 import EScriptEdit from "./EScriptEdit.vue";
@@ -98,6 +99,7 @@ const pageManager = inject("pageManager", {}) as PageManager;
 const visible = ref(false);
 const selectedKeys = ref<string[]>([]);
 const componentSchema = ref<ComponentSchema | null>(null);
+const argsEditorKey = ref<string>("");
 
 const emit = defineEmits(["add", "edit"]);
 
@@ -132,6 +134,16 @@ const methodOptions = computed(() => {
 
   return [];
 });
+
+watch(
+  () => componentSchema.value,
+  () => {
+    if (componentSchema.value) {
+      argsEditorKey.value = componentSchema.value.id!;
+    }
+  },
+  { immediate: true }
+);
 
 const actionArgsConfigs = computed(() => {
   if (state.actionItem.type === "component") {

--- a/packages/core/extensions/EActionEditor/src/EArgsEditor.vue
+++ b/packages/core/extensions/EActionEditor/src/EArgsEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="epic-attribute-view">
-    <div v-for="item in props.actionArgsConfigs" :key="item.field + item.type">
+    <div v-for="item in props.actionArgsConfigs" :key="item.field + item.type + item.id">
       <div v-show="isShow(item)" class="epic-attr-item" :class="item.layout">
         <div class="epic-attr-label" :title="item.label">
           {{ item.label }}


### PR DESCRIPTION

<img width="565" alt="e7c1715ac1a51ace39c49cab241b705" src="https://github.com/user-attachments/assets/641f5da2-62f5-4539-a978-e3b11b2bab9d" />
<img width="578" alt="f50649600929597eb55e30afec68990" src="https://github.com/user-attachments/assets/04a9952e-f8d4-411e-b37e-5e16abc59cbb" />

在事件配置中，如果相邻选择的组件是同一类型的，因为actionArgsConfigs可能是一样的，没有触发vue的更新
![image](https://github.com/user-attachments/assets/8f0c4354-ce53-40d7-ae6f-9873132df6f2)

监听选中的组件的变化，给EArgsEditor组件加上key可以解决这个问题。

EArgsEditor同时这个组件中的key似乎会出现重复的问题，type可能重复，field固定为0，所以同时加上id作为索引。
![image](https://github.com/user-attachments/assets/bdb05766-6452-4135-899e-10b9cd211f25)
