### PR TITLE
fix: 修复活动栏和侧边栏的显隐缺失响应式的问题

### DIFF
--- a/packages/utils/manager/pluginManager.ts
+++ b/packages/utils/manager/pluginManager.ts
@@ -364,16 +364,15 @@ export class PluginManager {
    * @param attr 匹配字段 title | id 默认值 title
    */
   hideActivitybar(value: string, attr: 'id' | 'title' = 'title') {
-    // 查找具有指定属性和值的活动栏的索引
-    const index = this.viewsContainers.activitybars.value.findIndex(
-      (rightSidebar) => rightSidebar[attr] === value,
-    );
-
-    // 如果找到匹配的活动栏
-    if (index !== -1) {
-      // 将匹配的活动栏的 'visible' 属性设置为 false
-      this.viewsContainers.activitybars.value[index].visible = false;
-    }
+    this.viewsContainers.activitybars.value =
+      this.viewsContainers.activitybars.value.map((activitybar) => {
+        // 查找具有指定属性和值的活动栏
+        if (activitybar[attr] === value) {
+          // 如果找到匹配的活动栏, 将匹配的活动栏的 'visible' 属性设置为 false
+          activitybar.visible = false;
+        }
+        return activitybar;
+      });
   }
 
   /**
@@ -391,16 +390,15 @@ export class PluginManager {
    * @param attr 查询字段 默认值 title
    */
   hideRightSidebar(value: string, attr: Atrr = 'title') {
-    // 查找具有指定属性和值的右侧边栏的索引
-    const index = this.viewsContainers.rightSidebars.value.findIndex(
-      (rightSidebar) => rightSidebar[attr] === value,
-    );
-
-    // 如果找到匹配的右侧边栏
-    if (index !== -1) {
-      // 将匹配的右侧边栏的 'visible' 属性设置为 false
-      this.viewsContainers.rightSidebars.value[index].visible = false;
-    }
+    this.viewsContainers.rightSidebars.value =
+      this.viewsContainers.rightSidebars.value.map((rightSidebar) => {
+        // 查找具有指定属性和值的右侧边栏
+        if (rightSidebar[attr] === value) {
+          // 如果找到匹配的右侧边栏, 将匹配的右侧边栏的 'visible' 属性设置为 false
+          rightSidebar.visible = false;
+        }
+        return rightSidebar;
+      });
   }
 
   /**
@@ -585,16 +583,15 @@ export class PluginManager {
    * @param attr 匹配字段 title | id 默认值 title
    */
   showActivitybar(value: string, attr: 'id' | 'title' = 'title') {
-    // 查找具有指定属性和值的活动栏的索引
-    const index = this.viewsContainers.activitybars.value.findIndex(
-      (rightSidebar) => rightSidebar[attr] === value,
-    );
-
-    // 如果找到匹配的活动栏
-    if (index !== -1) {
-      // 将匹配的活动栏的 'visible' 属性设置为 true
-      this.viewsContainers.activitybars.value[index].visible = true;
-    }
+    this.viewsContainers.activitybars.value =
+      this.viewsContainers.activitybars.value.map((activitybar) => {
+        // 查找具有指定属性和值的活动栏
+        if (activitybar[attr] === value) {
+          // 如果找到匹配的活动栏, 将匹配的活动栏的 'visible' 属性设置为 true
+          activitybar.visible = true;
+        }
+        return activitybar;
+      });
   }
 
   /**
@@ -614,16 +611,15 @@ export class PluginManager {
    * @param attr 查询字段 默认值 title
    */
   showRightSidebar(value: string, attr: Atrr = 'title') {
-    // 查找具有指定属性和值的右侧边栏的索引
-    const index = this.viewsContainers.rightSidebars.value.findIndex(
-      (rightSidebar) => rightSidebar[attr] === value,
-    );
-
-    // 如果找到匹配的右侧边栏
-    if (index !== -1) {
-      // 将匹配的右侧边栏的 'visible' 属性设置为 true
-      this.viewsContainers.rightSidebars.value[index].visible = true;
-    }
+    this.viewsContainers.rightSidebars.value =
+      this.viewsContainers.rightSidebars.value.map((rightSidebar) => {
+        // 查找具有指定属性和值的右侧边栏
+        if (rightSidebar[attr] === value) {
+          // 如果找到匹配的右侧边栏, 将匹配的右侧边栏的 'visible' 属性设置为 true
+          rightSidebar.visible = true;
+        }
+        return rightSidebar;
+      });
   }
 }
 


### PR DESCRIPTION
**复现示例 :**
```typescript
<script lang="ts" setup>
import { shallowRef, unref, watchEffect } from 'vue';

import { EDesigner, pluginManager } from '@epic-designer/core';
import { Space, Switch } from 'ant-design-vue';

const showEvent = shallowRef(true);
watchEffect(() => {
  if (unref(showEvent)) {
    pluginManager.showRightSidebar('event_view', 'id');
  } else {
    pluginManager.hideRightSidebar('event_view', 'id');
  }
});

const showOutline = shallowRef(true);
watchEffect(() => {
  if (unref(showOutline)) {
    pluginManager.showActivitybar('outline_view', 'id');
  } else {
    pluginManager.hideActivitybar('outline_view', 'id');
  }
});
</script>
<template>
  <Space>
    <Switch
      v-model:checked="showEvent"
      checked-children="显示事件页签"
      un-checked-children="隐藏事件页签"
    />
    <Switch
      v-model:checked="showOutline"
      checked-children="显示大纲"
      un-checked-children="隐藏大纲"
    />
  </Space>
  <EDesigner title="隐藏显示右侧边栏" />
</template>
```
**期待结果 :** 事件页签和大纲应该跟随`Switch`的值来显示或隐藏
**实际结果 :** 一直显示