### PR TITLE
fix(ci): 将unocss配置文件中的排除项移入content.pipeline.exclude，以修复构建报错问题

### DIFF
--- a/packages/epic-designer/uno.config.ts
+++ b/packages/epic-designer/uno.config.ts
@@ -3,17 +3,21 @@ import presetRemToPx from '@unocss/preset-rem-to-px';
 import { defineConfig, presetUno, transformerDirectives } from 'unocss';
 
 export default defineConfig({
-  exclude: [
-    'node_modules',
-    'dist',
-    '.git',
-    '.husky',
-    '.vscode',
-    'public',
-    'build',
-    'mock',
-    './stats.html',
-  ],
+  content: {
+    pipeline: {
+      exclude: [
+        'node_modules',
+        'dist',
+        '.git',
+        '.husky',
+        '.vscode',
+        'public',
+        'build',
+        'mock',
+        './stats.html',
+      ],
+    },
+  },
   presets: [presetUno({ dark: 'class' }), presetRemToPx()],
   shortcuts: {
     'flex-center': 'flex justify-center items-center',


### PR DESCRIPTION
**问题描述:** 由于github actions设置了环境变量`CI=true`，导致unocss报错，无法构建成功
**重现示例:** 
```bash
CI=true npm run build
```