### PR TITLE
fix: 🐛 EColEditor 删除图标 name 错误无法正常显示

### DIFF
--- a/packages/ui-kit/panel-ui/src/components/EColEditor/index.vue
+++ b/packages/ui-kit/panel-ui/src/components/EColEditor/index.vue
@@ -61,7 +61,10 @@ function handleDelete(index: number) {
       />
       <div v-if="colList.length > 1" class="epic-del-btn">
         <span @click="handleDelete(index)">
-          <EpicIcon name="icon--epic--delete-outline-rounded" />
+          <EpicIcon
+            class="hover:text-red cursor-pointer"
+            name="icon--epic--delete-outline-rounded"
+          />
         </span>
       </div>
     </div>

--- a/packages/ui-kit/panel-ui/src/components/EColEditor/index.vue
+++ b/packages/ui-kit/panel-ui/src/components/EColEditor/index.vue
@@ -61,7 +61,7 @@ function handleDelete(index: number) {
       />
       <div v-if="colList.length > 1" class="epic-del-btn">
         <span @click="handleDelete(index)">
-          <EpicIcon name="icon-shanchu1" />
+          <EpicIcon name="icon--epic--delete-outline-rounded" />
         </span>
       </div>
     </div>


### PR DESCRIPTION
解决 epic 0.9.18 图标调整遗留问题