### PR TITLE
fix: 被深拷贝的对象如果含有Proxy类型的字段则使用structuredClone报错

### DIFF
--- a/packages/utils/src/common/data.ts
+++ b/packages/utils/src/common/data.ts
@@ -20,13 +20,6 @@ export function deepClone<T extends object>(obj: T, cache = new WeakMap()): T {
     return cache.get(obj);
   }
 
-  // https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone
-  if (typeof window.structuredClone === 'function') {
-    const cloned = structuredClone(obj);
-    cache.set(obj, cloned);
-    return cloned;
-  }
-
   // 处理数组
   if (Array.isArray(obj)) {
     const clonedArray = obj.map((item) => deepClone(item as T, cache)) as T;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types
使用structuredClone函数时，如果被深拷贝的对象里有某个字段的类型为Proxy则会抛出异常： DataCloneError: Failed to execute 'structuredClone' on ‘window': #<Object> could not be cloned.