### PR TITLE
fix: 🐛 EActionEditor 解决无法绑定多个事件的问题

### DIFF
--- a/packages/ui-kit/panel-ui/src/components/EActionEditor/index.vue
+++ b/packages/ui-kit/panel-ui/src/components/EActionEditor/index.vue
@@ -139,7 +139,7 @@ function handleEdit(action: any) {
 function handleAdd(action: any) {
   modelValueComputed.value = {
     ...modelValueComputed.value,
-    [currentType]: [...(events.value[currentType]?.value || []), action],
+    [currentType]: [...(events.value[currentType] || []), action],
   };
 }
 </script>


### PR DESCRIPTION
handleAdd 里面获取 events 有误导致新增时一直清空已有 events