### PR TITLE
feat: 表单项自定义校验（checkPayload）与示例

### DIFF
--- a/examples/src/router/index.ts
+++ b/examples/src/router/index.ts
@@ -54,6 +54,14 @@ export const frameworkRoutes = [
           title: '公共方法',
         },
       },
+      {
+        path: 'customValidate',
+        name: 'customValidate',
+        component: () => import('@/views/designer/customValidate/index.vue'),
+        meta: {
+          title: '自定义校验组件',
+        },
+      },
     ],
   },
   {

--- a/examples/src/views/designer/customValidate/CustomValidateInput.vue
+++ b/examples/src/views/designer/customValidate/CustomValidateInput.vue
@@ -1,0 +1,127 @@
+<script lang="ts" setup>
+import { computed, useAttrs } from 'vue';
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+const props = withDefaults(
+  defineProps<{
+    disabled?: boolean;
+    hidden?: boolean;
+    modelValue?: string;
+    placeholder?: string;
+    readonly?: boolean;
+  }>(),
+  {
+    disabled: false,
+    hidden: false,
+    modelValue: '',
+    placeholder: '自定义校验组件',
+    readonly: false,
+  },
+);
+
+const emit = defineEmits([
+  'blur',
+  'change',
+  'check',
+  'focus',
+  'input',
+  'update:modelValue',
+]);
+
+const attrs = useAttrs();
+
+const innerValue = computed(() => props.modelValue ?? '');
+
+function emitCheck(value: string) {
+  const passed = value === 'ok';
+  emit('check', {
+    message: passed ? '校验通过' : 'check不通过',
+    result: passed,
+  });
+}
+
+function handleInput(event: Event) {
+  const value = (event.target as HTMLInputElement).value;
+  emit('update:modelValue', value);
+  emit('input', event);
+  emitCheck(value);
+}
+
+function handleChange(event: Event) {
+  emit('change', event);
+  emitCheck((event.target as HTMLInputElement).value);
+}
+
+function handleBlur(event: FocusEvent) {
+  emit('blur', event);
+  emitCheck((event.target as HTMLInputElement).value);
+}
+
+function handleFocus(event: FocusEvent) {
+  emit('focus', event);
+}
+</script>
+
+<template>
+  <div
+    v-show="!props.hidden"
+    class="custom-validate-input"
+    :class="{
+      'is-disabled': props.disabled,
+      'is-readonly': props.readonly,
+    }"
+  >
+    <input
+      v-bind="attrs"
+      class="custom-validate-input__control"
+      :disabled="props.disabled"
+      :placeholder="props.placeholder"
+      :readonly="props.readonly"
+      :value="innerValue"
+      type="text"
+      @blur="handleBlur"
+      @change="handleChange"
+      @focus="handleFocus"
+      @input="handleInput"
+    />
+  </div>
+</template>
+
+<style scoped>
+.custom-validate-input {
+  width: 100%;
+}
+
+.custom-validate-input__control {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 32px;
+  padding: 6px 12px;
+  border: 1px solid #d0d5dd;
+  border-radius: 8px;
+  outline: none;
+  background: #fff;
+  color: #101828;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.custom-validate-input__control:focus {
+  border-color: #1677ff;
+  box-shadow: 0 0 0 3px rgb(22 119 255 / 12%);
+}
+
+.custom-validate-input.is-disabled .custom-validate-input__control {
+  cursor: not-allowed;
+  background: #f5f5f5;
+  color: #98a2b3;
+}
+
+.custom-validate-input.is-readonly .custom-validate-input__control {
+  background: #f8fafc;
+}
+</style>

--- a/examples/src/views/designer/customValidate/customValidateComponent.ts
+++ b/examples/src/views/designer/customValidate/customValidateComponent.ts
@@ -1,0 +1,87 @@
+import type { ComponentConfigModel } from '@epic-designer/types';
+
+import CustomValidateInput from './CustomValidateInput.vue';
+
+export const CUSTOM_VALIDATE_COMPONENT_TYPE = 'custom-validate-input';
+
+const customValidateComponent: ComponentConfigModel = {
+  component: CustomValidateInput,
+  config: {
+    attribute: [
+      {
+        field: 'field',
+        label: '数据字段',
+        type: 'EpField',
+      },
+      {
+        field: 'label',
+        label: '标题',
+        type: 'input',
+      },
+      {
+        field: 'props.defaultValue',
+        label: '默认值',
+        type: 'input',
+      },
+      {
+        field: 'props.placeholder',
+        label: '提示词',
+        type: 'input',
+      },
+      {
+        field: 'props.readonly',
+        label: '只读',
+        type: 'switch',
+      },
+      {
+        field: 'props.disabled',
+        label: '禁用',
+        type: 'switch',
+      },
+      {
+        field: 'props.hidden',
+        label: '隐藏',
+        type: 'switch',
+      },
+      {
+        description: '校验规则需要配合表单使用',
+        field: 'rules',
+        label: '表单校验',
+        layout: 'vertical',
+        type: 'ERuleEditor',
+      },
+    ],
+    event: [
+      {
+        description: '输入值时',
+        type: 'input',
+      },
+      {
+        description: '值修改时',
+        type: 'change',
+      },
+      {
+        description: '获取焦点时',
+        type: 'focus',
+      },
+      {
+        description: '失去焦点时',
+        type: 'blur',
+      },
+    ],
+  },
+  defaultSchema: {
+    field: 'customCheck',
+    input: true,
+    label: '自定义校验组件',
+    props: {
+      placeholder: '自定义校验组件',
+    },
+    type: CUSTOM_VALIDATE_COMPONENT_TYPE,
+  },
+  groupName: '表单',
+  icon: 'icon--epic--shield-check-outline-rounded',
+  sort: 130,
+};
+
+export default customValidateComponent;

--- a/examples/src/views/designer/customValidate/index.vue
+++ b/examples/src/views/designer/customValidate/index.vue
@@ -1,0 +1,129 @@
+<script lang="ts" setup>
+import type { PageSchema } from '@epic-designer/types';
+
+import {
+  onActivated,
+  onBeforeUnmount,
+  onDeactivated,
+  onMounted,
+  ref,
+} from 'vue';
+
+import { EDesigner } from '@epic-designer/core';
+
+import {
+  hideCustomValidateComponent,
+  showCustomValidateComponent,
+} from './registerCustomValidateComponent';
+
+const designerRef = ref<InstanceType<typeof EDesigner>>();
+
+const pageSchema: PageSchema = {
+  canvas: {
+    mode: 'desktop',
+  },
+  schemas: [
+    {
+      id: 'root',
+      label: '页面',
+      props: {
+        style: {
+          padding: '16px',
+        },
+      },
+      type: 'page',
+      children: [
+        {
+          label: '表单',
+          type: 'form',
+          children: [
+            {
+              field: 'customCheck',
+              id: 'custom_validate_1',
+              input: true,
+              label: '自定义校验组件',
+              props: {
+                placeholder: '输入 ok 则校验通过',
+              },
+              rules: [
+                {
+                  isValidator: true,
+                  message: '请输入 ok，其他内容 check 不通过',
+                  trigger: ['change', 'blur'],
+                  validator: 'validateCustomCheck',
+                },
+              ],
+              type: 'custom-validate-input',
+            },
+          ],
+          id: 'form_custom_validate',
+          props: {
+            labelCol: {
+              span: 5,
+            },
+            labelLayout: 'fixed',
+            labelWidth: '120px',
+            name: 'default',
+            wrapperCol: {
+              span: 19,
+            },
+          },
+        },
+      ],
+    },
+  ],
+  script: `const { defineExpose } = epic;
+
+function validateCustomCheck(_rule, value, callback) {
+  if (value === 'ok') {
+    callback?.();
+    return Promise.resolve();
+  }
+
+  const error = new Error('请输入 ok，其他内容 check 不通过');
+  callback?.(error);
+  return Promise.reject(error);
+}
+
+defineExpose({
+  validateCustomCheck,
+});`,
+};
+
+function syncMaterialVisible(visible: boolean) {
+  if (visible) {
+    showCustomValidateComponent();
+    return;
+  }
+
+  hideCustomValidateComponent();
+}
+
+onMounted(() => {
+  syncMaterialVisible(true);
+  designerRef.value?.setData(pageSchema);
+});
+
+onActivated(() => {
+  syncMaterialVisible(true);
+});
+
+onDeactivated(() => {
+  syncMaterialVisible(false);
+});
+
+onBeforeUnmount(() => {
+  syncMaterialVisible(false);
+});
+
+function handleSubmit(e: PageSchema) {
+  console.log(e);
+}
+</script>
+<template>
+  <EDesigner ref="designerRef" title="自定义校验组件示例" @save="handleSubmit">
+    <template #header-prefix>
+      <div>欢迎使用EpicDesigner设计器</div>
+    </template>
+  </EDesigner>
+</template>

--- a/examples/src/views/designer/customValidate/registerCustomValidateComponent.ts
+++ b/examples/src/views/designer/customValidate/registerCustomValidateComponent.ts
@@ -1,0 +1,23 @@
+import { pluginManager } from '@epic-designer/manager';
+
+import customValidateComponent, {
+  CUSTOM_VALIDATE_COMPONENT_TYPE,
+} from './customValidateComponent';
+
+function ensureRegistered() {
+  if (
+    !pluginManager.component.getConfigByType(CUSTOM_VALIDATE_COMPONENT_TYPE)
+  ) {
+    pluginManager.component.register(customValidateComponent);
+  }
+}
+
+export function showCustomValidateComponent() {
+  ensureRegistered();
+  pluginManager.component.show(CUSTOM_VALIDATE_COMPONENT_TYPE);
+}
+
+export function hideCustomValidateComponent() {
+  ensureRegistered();
+  pluginManager.component.hide(CUSTOM_VALIDATE_COMPONENT_TYPE);
+}

--- a/packages/ui-kit/base-ui/src/node/dynamicFormItem.vue
+++ b/packages/ui-kit/base-ui/src/node/dynamicFormItem.vue
@@ -6,10 +6,16 @@ import type { VNode } from 'vue';
 import { usePageManager } from '@epic-designer/hooks';
 import { pluginManager } from '@epic-designer/manager';
 
+type FormItemCheckPayload = {
+  message?: string;
+  result?: boolean;
+};
+
 defineOptions({
   inheritAttrs: false,
 });
 const props = defineProps<{
+  checkPayload?: FormItemCheckPayload | null;
   formItemProps: ComponentSchema;
   hasFormItem?: boolean;
 }>();
@@ -36,6 +42,7 @@ const addFormItemInstance = (vNode: VNode) => {
   <!-- 如果有 FormItem，则包裹 slot，否则直接渲染 slot -->
   <FormItem
     v-if="props.hasFormItem"
+    :check-payload="props.checkPayload"
     v-bind="props.formItemProps"
     :class="{ 'epic-hidden': props.formItemProps.props?.hidden }"
     @vue:mounted="addFormItemInstance"

--- a/packages/ui-kit/base-ui/src/node/node.vue
+++ b/packages/ui-kit/base-ui/src/node/node.vue
@@ -149,6 +149,7 @@ if (Object.keys(attrs).length > 0) {
 
 // 定义组件及组件props字段
 const componentRef = shallowRef<any>(null);
+const checkPayload = ref<null | { message?: string; result?: boolean }>(null);
 
 const fieldStateType = ref<FieldStateType | null>(null);
 const fieldRequired = ref<boolean | null | undefined>(null);
@@ -303,6 +304,10 @@ const getProps = computed(() => {
     ...onEvent,
   };
 });
+
+function handleCheck(payload: { message?: string; result?: boolean }) {
+  checkPayload.value = payload;
+}
 
 // 添加组件实例
 function handleAddComponentInstance(vNode?: VNode) {
@@ -466,6 +471,7 @@ onBeforeUnmount(handleVnodeUnmounted);
 <template>
   <dynamicFormItem
     v-if="componentRef && show"
+    :check-payload="checkPayload"
     :has-form-item="
       innerSchema.noFormItem !== true && getComponentConfig?.defaultSchema.input
     "
@@ -477,6 +483,7 @@ onBeforeUnmount(handleVnodeUnmounted);
       v-model:[getProps.bindModel]="innerValue"
       :model="formData"
       :class="{ 'epic-hidden': innerSchema.props?.hidden }"
+      @check="handleCheck"
       @vue:mounted="handleAddComponentInstance"
     >
       <!-- 嵌套组件递归 start -->

--- a/packages/ui/antd/src/form-item/formItem.vue
+++ b/packages/ui/antd/src/form-item/formItem.vue
@@ -1,9 +1,31 @@
 <script lang="ts" setup>
-import { useAttrs } from 'vue';
+import { computed, useAttrs } from 'vue';
 
 import { FormItem } from 'ant-design-vue';
 
-const attrs = useAttrs() as any;
+type FormItemCheckPayload = {
+  message?: string;
+  result?: boolean;
+};
+
+const props = defineProps<{
+  checkPayload?: FormItemCheckPayload | null;
+}>();
+
+const rawAttrs = useAttrs();
+const attrs = computed<any>(() => {
+  if (!props.checkPayload) {
+    return rawAttrs;
+  }
+
+  return {
+    ...rawAttrs,
+    help:
+      props.checkPayload.message ??
+      (props.checkPayload.result ? '校验通过' : '校验失败'),
+    validateStatus: props.checkPayload.result ? 'success' : 'error',
+  };
+});
 </script>
 <template>
   <FormItem v-bind="attrs" :name="attrs.field">

--- a/packages/ui/elementPlus/src/formItem/formItem.vue
+++ b/packages/ui/elementPlus/src/formItem/formItem.vue
@@ -1,9 +1,31 @@
 <script lang="ts" setup>
-import { ref, useAttrs } from 'vue';
+import { computed, ref, useAttrs } from 'vue';
 
 import { ElFormItem } from 'element-plus';
 
-const attrs = useAttrs() as any;
+type FormItemCheckPayload = {
+  message?: string;
+  result?: boolean;
+};
+
+const props = defineProps<{
+  checkPayload?: FormItemCheckPayload | null;
+}>();
+
+const rawAttrs = useAttrs();
+const attrs = computed<any>(() => {
+  if (!props.checkPayload) {
+    return rawAttrs;
+  }
+
+  return {
+    ...rawAttrs,
+    error: props.checkPayload.result
+      ? ''
+      : (props.checkPayload.message ?? '校验失败'),
+    validateStatus: props.checkPayload.result ? 'success' : 'error',
+  };
+});
 const form = ref<any>(null);
 </script>
 <template>

--- a/packages/ui/naiveUi/src/form-item/formItem.vue
+++ b/packages/ui/naiveUi/src/form-item/formItem.vue
@@ -1,9 +1,32 @@
 <script lang="ts" setup>
-import { ref, useAttrs } from 'vue';
+import { computed, ref, useAttrs } from 'vue';
 
 import { NFormItem } from 'naive-ui/lib/form';
 
-const attrs = useAttrs() as any;
+type FormItemCheckPayload = {
+  message?: string;
+  result?: boolean;
+};
+
+const props = defineProps<{
+  checkPayload?: FormItemCheckPayload | null;
+}>();
+
+const rawAttrs = useAttrs();
+const attrs = computed<any>(() => {
+  if (!props.checkPayload) {
+    return rawAttrs;
+  }
+
+  return {
+    ...rawAttrs,
+    feedback:
+      props.checkPayload.message ??
+      (props.checkPayload.result ? '校验通过' : '校验失败'),
+    showFeedback: true,
+    validationStatus: props.checkPayload.result ? 'success' : 'error',
+  };
+});
 const form = ref<any>(null);
 </script>
 <template>


### PR DESCRIPTION
本 PR 在 Ant Design / Element Plus / Naive UI 三套表单项封装中统一接入 checkPayload，用于把外部校验结果映射为表单项的校验状态与提示文案；并在 dynamicFormItem、node 中向下传递该能力。另增加 Designer 自定义校验组件示例（路由 + 注册 + 演示页），便于对接自定义校验逻辑。

## 变更说明
### 1. 核心能力（5ffa3bf）
  - 为各 UI 库的 form-item 增加 checkPayload，用计算属性驱动 校验状态与反馈信息。
  - 在 base-ui 的 node.vue、dynamicFormItem.vue 中传递 checkPayload，使动态表单项能展示校验结果。

#### 涉及文件：

- packages/ui-kit/base-ui/src/node/node.vue
- packages/ui-kit/base-ui/src/node/dynamicFormItem.vue
- packages/ui/antd/src/form-item/formItem.vue
- packages/ui/elementPlus/src/formItem/formItem.vue
- packages/ui/naiveUi/src/form-item/formItem.vue
### 2. 示例与文档化用法（bb6f327）
- 路由增加 自定义校验 入口。
- 新增自定义输入组件、组件配置、registerCustomValidateComponent 注册逻辑及 index.vue 演示页，展示自定义校验如何与表单项配合。
#### 涉及文件：

- examples/src/router/index.ts
- examples/src/views/designer/customValidate/*（含 CustomValidateInput.vue、customValidateComponent.ts、registerCustomValidateComponent.ts、index.vue）
## 提交记录
- 5ffa3bf feat: 添加表单项校验功能（checkPayload + 动态表单项透传）
- bb6f327 feat: 添加自定义校验组件 demo（路由 + 示例页）
## 测试建议
在 examples 中打开 自定义校验 路由，确认三种 UI 主题（若示例支持切换）下表单项错误态与提示是否正常。
Designer 中拖入/使用自定义校验组件，确认校验触发与展示符合预期。
